### PR TITLE
Separate hashing from the bind method

### DIFF
--- a/internal/handler/request/userRegister.go
+++ b/internal/handler/request/userRegister.go
@@ -20,10 +20,6 @@ func (r *UserRegisterRequest) Bind(c *fiber.Ctx, u *model.User) error {
 
 	u.Username = r.User.Username
 	u.Email = r.User.Email
-	h, err := u.HashPassword(r.User.Password)
-	if err != nil {
-		return err
-	}
-	u.Password = h
+
 	return nil
 }

--- a/internal/handler/request/userUpdate.go
+++ b/internal/handler/request/userUpdate.go
@@ -33,13 +33,6 @@ func (r *UserUpdateRequest) Bind(c *fiber.Ctx, u *model.User) error {
 	}
 	u.Username = r.User.Username
 	u.Email = r.User.Email
-	if r.User.Password != u.Password {
-		h, err := u.HashPassword(r.User.Password)
-		if err != nil {
-			return err
-		}
-		u.Password = h
-	}
 	u.Bio = &r.User.Bio
 	u.Image = &r.User.Image
 	return nil

--- a/internal/handler/user.go
+++ b/internal/handler/user.go
@@ -21,6 +21,11 @@ func (h *Handler) Register(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnprocessableEntity).SendString(err.Error())
 	}
 
+	err := user.HashPassword(req.User.Password)
+	if err != nil {
+		return err
+	}
+
 	if err := h.userStore.Create(&user); err != nil {
 		return c.Status(http.StatusUnprocessableEntity).SendString(err.Error())
 	}
@@ -72,6 +77,12 @@ func (h *Handler) UpdateUser(c *fiber.Ctx) error {
 
 	if err := req.Bind(c, user); err != nil {
 		return c.SendStatus(http.StatusUnprocessableEntity)
+	}
+	if req.User.Password != user.Password {
+		err := user.HashPassword(req.User.Password)
+		if err != nil {
+			return err
+		}
 	}
 
 	return c.Status(http.StatusOK).JSON(response.NewUserResponse(user))

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -29,12 +29,18 @@ func (Follow) TableName() string {
 	return "follows"
 }
 
-func (u *User) HashPassword(plainPassword string) (string, error) {
+func (u *User) HashPassword(plainPassword string) error {
 	if len(plainPassword) == 0 {
-		return "", errors.New("password should not be empty")
+		u.Password = ""
+		return errors.New("password should not be empty")
 	}
 	h, err := bcrypt.GenerateFromPassword([]byte(plainPassword), bcrypt.DefaultCost)
-	return string(h), err
+	if err != nil {
+		return err
+	}
+
+	u.Password = string(h)
+	return nil
 }
 
 func (u *User) CheckPassword(plainPassword string) bool {


### PR DESCRIPTION
Modify the Bind function to solely handle the mapping of request data to the User struct. Remove the password hashing logic from this method.